### PR TITLE
bug: Fix ports, and port description

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.20
 require (
 	github.com/ethereum/go-ethereum v1.11.5
 	github.com/gorilla/mux v1.8.0
-	github.com/marioevz/eth-clients v0.0.0-20230501225027-135b7d52b617
+	github.com/marioevz/eth-clients v0.0.0-20230519160836-0e770d3e5659
 	github.com/protolambda/bls12-381-util v0.0.0-20220416220906-d8552aa452c7
 	github.com/protolambda/eth2api v0.0.0-20230316214135-5f8afbd6d05d
 	github.com/protolambda/zrnt v0.30.0

--- a/go.sum
+++ b/go.sum
@@ -201,6 +201,10 @@ github.com/labstack/gommon v0.3.0/go.mod h1:MULnywXg0yavhxWKc+lOruYdAhDwPK9wf0OL
 github.com/magiconair/properties v1.8.0/go.mod h1:PppfXfuXeibc/6YijjN8zIbojt8czPbwD3XqdrwzmxQ=
 github.com/marioevz/eth-clients v0.0.0-20230501225027-135b7d52b617 h1:sk4stg95D93cfiIIYI+XPRhXZQ91QGIPOHNDZjmpXms=
 github.com/marioevz/eth-clients v0.0.0-20230501225027-135b7d52b617/go.mod h1:LnzXFKyMw3wF/3eaTfPhKiwkWkZJXokOWcUI02Ioi4s=
+github.com/marioevz/eth-clients v0.0.0-20230503173323-98293c926363 h1:ONwsdY5/heIE0HHxh4+QXkwa69MZuaO+vONXduNBbrM=
+github.com/marioevz/eth-clients v0.0.0-20230503173323-98293c926363/go.mod h1:LnzXFKyMw3wF/3eaTfPhKiwkWkZJXokOWcUI02Ioi4s=
+github.com/marioevz/eth-clients v0.0.0-20230519160836-0e770d3e5659 h1:/N3xEgaeM7GvDtG1wDsypbMA1SOwbeby1gWH2qc7zTY=
+github.com/marioevz/eth-clients v0.0.0-20230519160836-0e770d3e5659/go.mod h1:LnzXFKyMw3wF/3eaTfPhKiwkWkZJXokOWcUI02Ioi4s=
 github.com/mattn/go-colorable v0.1.2/go.mod h1:U0ppj6V5qS13XJ6of8GYAs25YV2eR4EVcfRqFIhoBtE=
 github.com/mattn/go-colorable v0.1.8/go.mod h1:u6P/XSegPjTcexA+o6vUJrdnUu04hMope9wVRipJSqc=
 github.com/mattn/go-colorable v0.1.11/go.mod h1:u5H1YNBxpqRaxsYJYSkiCWKzEfiAb1Gb520KVy5xxl4=


### PR DESCRIPTION
The execution client engine API port could be specified in the url by using "<IP>:<Engine API Port>", but the RPC port would always be the default.

A new command line argument was added `--el-rpc-port` to specify a custom RPC port number.