### PR TITLE
Store and serve validation errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,3 +78,6 @@ The callback can then use the slot number to determine whether to throw an error
 - `DELETE` `/mock/invalid/payload`: Disables any modification to payload built
 - `POST` `/mock/invalid/payload/{type}`: Enables specified [type](#payload-invalidation-types) of modification to payload built
 - `POST` `/mock/invalid/payload/{type}/<slot|epoch>/{slot/epoch number}`: Enables specified [type](#payload-invalidation-types) of modification to payload built starting at the slot or epoch specified
+
+# Statistics
+- `GET` `/mock/stats/validation_errors`: Returns a JSON containing all the errors encountered when validating the submitted signed blinded responses from the consensus client (e.g. Invalid signature on submitted blinded block, invalid signature on submitted blinded blob sidecar)


### PR DESCRIPTION
Store and serve the list of errors (and slot number) that were encountered during validation of the submitted signed beacon response from the consensus client.

This is helpful to find issues where the consensus client submitted an invalid signature or malformed struct in the signed blinded beacon block, or signed blinded blob sidecars.

It does not detect if the beacon block is invalid (e.g. when appended to the beacon chain). 